### PR TITLE
Remove mentions of git.eclipse.org and gerrit

### DIFF
--- a/plugins/org.eclipse.emf.compare.doc/pom.xml
+++ b/plugins/org.eclipse.emf.compare.doc/pom.xml
@@ -152,7 +152,7 @@
   <profiles>
     <profile>
       <!--
-        Do the javadoc generation in a profile to keep standard builds (e.g. gerrit) fast.
+        Do the javadoc generation in a profile to keep standard builds (e.g. Pull Requests) fast.
       -->
       <id>javadoc</id>
       <build>

--- a/plugins/org.eclipse.emf.compare.doc/src/FAQ.mediawiki
+++ b/plugins/org.eclipse.emf.compare.doc/src/FAQ.mediawiki
@@ -59,7 +59,7 @@ The [http://www.eclipse.org/emf/compare/downloads/ Download page] lists more spe
 
 '''Q''' : How can I use EMF Compare programmatically, to compare either files or "in-memory" objects?
 
-'''A''' : Many samples of how to compare objects can be found within [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare.tests the unit tests of EMF Compare] (see also [[EMF_Compare/Contributor_Guide#Checking_out_the_code|how to checkout the source code]]). Here is a sample that should cover the basic use case (the class with this method should have a dependency towards the ''org.eclipse.emf.compare'' plugin) :
+'''A''' : Many samples of how to compare objects can be found within [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare.tests the unit tests of EMF Compare] (see also [[EMF_Compare/Contributor_Guide#Checking_out_the_code|how to checkout the source code]]). Here is a sample that should cover the basic use case (the class with this method should have a dependency towards the ''org.eclipse.emf.compare'' plugin) :
 
 <source lang="java">
 public void compare(File model1, File model2) {

--- a/plugins/org.eclipse.emf.compare.doc/src/developer/developer-guide.mediawiki
+++ b/plugins/org.eclipse.emf.compare.doc/src/developer/developer-guide.mediawiki
@@ -197,7 +197,7 @@ The goal of the "Match" phase is to discover which of the objects from model 2 m
 
 By default, EMF Compare browses through elements that are within the scope, and matches them through their identifier if they have one, or through a distance mechanism for all elements that have none. If the scope contains resources, EMF Compare will first match those two-by-two before browsing through all of their contained objects.
 
-EMF Compare "finds" the identifier of a given object through a basic function that can be found in [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/eobject/IdentifierEObjectMatcher.java#n268 IdentifierEObjectMatcher.DefaultIDFunction]. In short, if the object is a proxy, its identifier is its URI fragment. Otherwise its XMI ID (the identifier it was given in the XMI file) takes precedence over its functional ID (in ecore, an attribute that serves as an identifier). If the object is not a proxy and has neither XMI nor functional identifier, then the default behavior will simply pass that object over to the proximity algorithms so that it can be matched through its distance with other objects.
+EMF Compare "finds" the identifier of a given object through a basic function that can be found in [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/eobject/IdentifierEObjectMatcher.java#L308 IdentifierEObjectMatcher.DefaultIDFunction]. In short, if the object is a proxy, its identifier is its URI fragment. Otherwise its XMI ID (the identifier it was given in the XMI file) takes precedence over its functional ID (in ecore, an attribute that serves as an identifier). If the object is not a proxy and has neither XMI nor functional identifier, then the default behavior will simply pass that object over to the proximity algorithms so that it can be matched through its distance with other objects.
 
 PENDING: brief description of the proximity algorithm
 
@@ -229,7 +229,7 @@ EMFCompare.builder().setMatchEngineFactoryRegistry(registry).build().compare(sco
 
 By default, the logic EMF Compare uses to match resources together is very simple: if two resources have the same name (strict equality on the name, without considering folders), they match. When this is not sufficient, EMF Compare will look at the XMI ID of the resources' root(s). If the two resources share at least one root with an equal XMI ID, they match.
 
-This can be changed by just implementing your own subclass of the DefaultMatchEngine and overriding its resource matcher. The method of interest here is [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/DefaultMatchEngine.java#n319 DefaultMatchEngine#createResourceMatcher()].
+This can be changed by just implementing your own subclass of the DefaultMatchEngine and overriding its resource matcher. The method of interest here is [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/DefaultMatchEngine.java#L359 DefaultMatchEngine#createResourceMatcher()].
 
 ==== Defining custom identifiers ====
 

--- a/plugins/org.eclipse.emf.compare.doc/src/developer/developer-guide.mediawiki
+++ b/plugins/org.eclipse.emf.compare.doc/src/developer/developer-guide.mediawiki
@@ -197,7 +197,7 @@ The goal of the "Match" phase is to discover which of the objects from model 2 m
 
 By default, EMF Compare browses through elements that are within the scope, and matches them through their identifier if they have one, or through a distance mechanism for all elements that have none. If the scope contains resources, EMF Compare will first match those two-by-two before browsing through all of their contained objects.
 
-EMF Compare "finds" the identifier of a given object through a basic function that can be found in [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/eobject/IdentifierEObjectMatcher.java#n268 IdentifierEObjectMatcher.DefaultIDFunction]. In short, if the object is a proxy, its identifier is its URI fragment. Otherwise its XMI ID (the identifier it was given in the XMI file) takes precedence over its functional ID (in ecore, an attribute that serves as an identifier). If the object is not a proxy and has neither XMI nor functional identifier, then the default behavior will simply pass that object over to the proximity algorithms so that it can be matched through its distance with other objects.
+EMF Compare "finds" the identifier of a given object through a basic function that can be found in [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/eobject/IdentifierEObjectMatcher.java#n268 IdentifierEObjectMatcher.DefaultIDFunction]. In short, if the object is a proxy, its identifier is its URI fragment. Otherwise its XMI ID (the identifier it was given in the XMI file) takes precedence over its functional ID (in ecore, an attribute that serves as an identifier). If the object is not a proxy and has neither XMI nor functional identifier, then the default behavior will simply pass that object over to the proximity algorithms so that it can be matched through its distance with other objects.
 
 PENDING: brief description of the proximity algorithm
 
@@ -205,7 +205,7 @@ This behavior can be customized in a number of ways.
 
 ==== Overriding the Match engine ====
 
-The most powerful (albeit most cumbersome) customization you can implement is to override the match engine EMF Compare uses. To this end you can either implement the whole contract, [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/IMatchEngine.java ''IMatchEngine''], in which case you will have to carefully follow the javadoc's recommendations, or extend the default implementation, [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/DefaultMatchEngine.java ''DefaultMatchEngine''].
+The most powerful (albeit most cumbersome) customization you can implement is to override the match engine EMF Compare uses. To this end you can either implement the whole contract, [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/IMatchEngine.java ''IMatchEngine''], in which case you will have to carefully follow the javadoc's recommendations, or extend the default implementation, [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/DefaultMatchEngine.java ''DefaultMatchEngine''].
 
 A custom match engine can be used for your model comparison needs:
 
@@ -229,7 +229,7 @@ EMFCompare.builder().setMatchEngineFactoryRegistry(registry).build().compare(sco
 
 By default, the logic EMF Compare uses to match resources together is very simple: if two resources have the same name (strict equality on the name, without considering folders), they match. When this is not sufficient, EMF Compare will look at the XMI ID of the resources' root(s). If the two resources share at least one root with an equal XMI ID, they match.
 
-This can be changed by just implementing your own subclass of the DefaultMatchEngine and overriding its resource matcher. The method of interest here is [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/DefaultMatchEngine.java#n319 DefaultMatchEngine#createResourceMatcher()].
+This can be changed by just implementing your own subclass of the DefaultMatchEngine and overriding its resource matcher. The method of interest here is [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/match/DefaultMatchEngine.java#n319 DefaultMatchEngine#createResourceMatcher()].
 
 ==== Defining custom identifiers ====
 
@@ -295,7 +295,7 @@ As such, you can impact all of the differencing process through this. Within thi
 : unmatched elements have two or three associated ''Match'' objects. For example if you are comparing three version of a model which all contain a different version of a given package, and all three version change the name of this package: version 1 has package "P1", version 2 has package "P2" and version three has package "P3". This package is actually the same, but EMF Compare did not manage to match it. We will thus have three ''Match'' objects: one that references "P1" as ''left'', one that references "P2" as ''right'' and one that references "P3" as ''origin''.
 : You may remove two of those three elements and change the third one so that it references P1 as ''left'', P2 as ''right'' and P3 as ''origin''. In such a case, those three will be considered to Match for the remainder of the comparison process. Make sure that there are not two different ''Match'' referencing the same object though, as this would yield unspecified results.
 
-Defining a custom post-processor requires you to implement [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/postprocessor/IPostProcessor.java IPostProcessor] and registering this sub-class against EMF Compare. The latter can be done via either an extension point, in which case it will be considered for '''all''' comparisons on models that match its enablement, or programmatically if you only want it active for your own actions:
+Defining a custom post-processor requires you to implement [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/postprocessor/IPostProcessor.java IPostProcessor] and registering this sub-class against EMF Compare. The latter can be done via either an extension point, in which case it will be considered for '''all''' comparisons on models that match its enablement, or programmatically if you only want it active for your own actions:
 
 '''Through code'''
 
@@ -334,7 +334,7 @@ Customizations of this phase usually aim at ignoring specific differences.
 
 ==== Overriding the Diff engine ====
 
-As is the case for the Match phase, the most powerful customization you can implement for the differencing process is to override the diff engine EMF Compare uses. To this end you can either implement the whole contract, [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/IDiffEngine.java ''IDiffEngine''], in which case you will have to carefully follow the javadoc's recommendations, or extend the default implementation, [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/DefaultDiffEngine.java ''DefaultDiffEngine''].
+As is the case for the Match phase, the most powerful customization you can implement for the differencing process is to override the diff engine EMF Compare uses. To this end you can either implement the whole contract, [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/IDiffEngine.java ''IDiffEngine''], in which case you will have to carefully follow the javadoc's recommendations, or extend the default implementation, [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/DefaultDiffEngine.java ''DefaultDiffEngine''].
 
 A custom diff engine can then be used for your comparisons:
 
@@ -377,7 +377,7 @@ You could also [[#Changing the Diff Processor|change the diff processor]] to ach
 
 The diff engine browses over all of the objects that have been matched, and checks all of their features in order to check for changes between the two (or three) versions' feature values. When it detects a change, it delegates all of the corresponding information to its associated ''Diff Processor'', which is in charge of actually creating the ''Diff'' object and appending it to the resulting ''Comparison''.
 
-Replacing the ''Diff Processor'' gives you a simple entry point to ignore some of the differences the default engine detects, or to slightly alter the ''Diff'' information. You might want to ignore the differences detected on some references for example. Or you might want to react to the detected diff without actually creating the ''Comparison'' model... The implementation is up to you. You can either re-implement the [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/IDiffProcessor.java whole contract] or extend the default implementation, [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/DiffBuilder.java ''DiffBuilder'']
+Replacing the ''Diff Processor'' gives you a simple entry point to ignore some of the differences the default engine detects, or to slightly alter the ''Diff'' information. You might want to ignore the differences detected on some references for example. Or you might want to react to the detected diff without actually creating the ''Comparison'' model... The implementation is up to you. You can either re-implement the [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/IDiffProcessor.java whole contract] or extend the default implementation, [https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/diff/DiffBuilder.java ''DiffBuilder'']
 
 Here is a simple example that provides EMF Compare with a diff processor that will ignore all differences detected on the "name" attribute of our objects, yet keep the default behavior for all other differences.
 

--- a/plugins/org.eclipse.emf.compare.doc/src/tutorial/tutorial.mediawiki
+++ b/plugins/org.eclipse.emf.compare.doc/src/tutorial/tutorial.mediawiki
@@ -32,9 +32,9 @@ This tutorial is based on the well know ExtLibrary meta-model (available from th
 
 ===== Import the plugins =====
 
-Those plugins are hosted in the [[http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git |EMF Compare repository]]. To import those plugins in your workspace you can follow the [[http://wiki.eclipse.org/EGit/User_Guide#Starting_from_existing_Git_Repositories | EGit tutorial]]. Here are the main steps:
+Those plugins are hosted in the [[https://github.com/eclipse-emf-compare/emf-compare |EMF Compare repository]]. To import those plugins in your workspace you can follow the [[http://wiki.eclipse.org/EGit/User_Guide#Starting_from_existing_Git_Repositories | EGit tutorial]]. Here are the main steps:
 * Clone EMF Compare repository using the following URL (see [[http://wiki.eclipse.org/EGit/User_Guide#Cloning_Remote_Repositories | Clone a repository]] for further information):
-** http://git.eclipse.org/gitroot/emfcompare/org.eclipse.emf.compare.git 
+** https://github.com/eclipse-emf-compare/emf-compare 
 * Import the required plugins into your workspace:
 ** Open the "Git Repositories" view (if not already opened): Window > "Show view" > "Other...".
 ** Select "Git Repositories".

--- a/plugins/org.eclipse.emf.compare.doc/src/user/git-commands-involving-models.mediawiki
+++ b/plugins/org.eclipse.emf.compare.doc/src/user/git-commands-involving-models.mediawiki
@@ -74,7 +74,7 @@ Once created, you will able to modify the setup model. You can also create a set
 
 Please visit [http://www.eclipse.org/oomph Oomph website] for more details about Oomph.
 
-You can find an example of setup model file for EMF compare's Git commands here: [http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare-cli.git/tree/examples/SetupExamples Setup Example]
+You can find an example of setup model file for EMF compare's Git commands here: [https://github.com/eclipse-emf-compare/emf-compare-cli/tree/master/examples/SetupExamples Setup Example]
 This example contains a workspace location to edit, an installation location to edit, and additional plugins to take into account for the git command to execute. These additional plugins are Papyrus, UML2, GMF, and EMF Compare extensions.
 
 == Git diff command with models : git logicaldiff ==
@@ -478,18 +478,6 @@ org.osgi.framework.BundleException: Could not resolve module: org.eclipse.equino
 
 A bug has been reported concerning this error: https://bugs.eclipse.org/bugs/show_bug.cgi?id=453432
 	
-=== Merge tool ===
-
-The merge tool doesn't work correctly on logical models. the problem is known and a patch has been made to fix it.
-Since the problem concerns EGit & EMF Compare, we need to stay EGit team to integrate the following contribution:
-*https://git.eclipse.org/r/#/c/36026/
-
-Once integrated, the following EMF Compare contributions will be integrated too:
-*https://git.eclipse.org/r/#/c/35541/
-*https://git.eclipse.org/r/#/c/36025/
-
-Then, the merge tool will work correctly.
-
 === Cherry-pick empty commit ===
 
 If you try to cherry-pick a commit that introduces changes that already belong to the worktree, the operation may stop on a dirty state. For example, if you have cherry-picked a commit that belongs to the ancestor tree of HEAD. The characteristics of this dirty state are:

--- a/plugins/org.eclipse.emf.compare.specifications/pom.xml
+++ b/plugins/org.eclipse.emf.compare.specifications/pom.xml
@@ -152,7 +152,7 @@
   <profiles>
     <profile>
       <!--
-        Do the javadoc generation in a profile to keep standard builds (e.g. gerrit) fast.
+        Do the javadoc generation in a profile to keep standard builds (e.g. Pull requests) fast.
       -->
       <id>javadoc</id>
       <build>

--- a/plugins/org.eclipse.emf.compare.specifications/src/3.2.0-release.mediawiki
+++ b/plugins/org.eclipse.emf.compare.specifications/src/3.2.0-release.mediawiki
@@ -17,7 +17,7 @@ This user story is linked with these bugs & reviews:
 === Related Tests ===
 
 This user story is linked with these tests:
-* http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare.uml2.tests/src/org/eclipse/emf/compare/uml2/tests/stereotypes/DanglingStereotypeApplicationTest.java
+* https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare.uml2.tests/src/org/eclipse/emf/compare/uml2/tests/stereotypes/DanglingStereotypeApplicationTest.java
 
 === Content ===
 
@@ -410,8 +410,8 @@ This user story is linked with these bugs & reviews:
 === Related Tests ===
 
 This user story is linked with these tests:
-* https://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare.diagram.papyrus.tests/src/org/eclipse/emf/compare/diagram/papyrus/tests/difile/IgnoreDiFilePostProcessorTest.java
-* https://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare.diagram.papyrus.tests.git/src/org/eclipse/emf/compare/diagram/papyrus/tests/egit/IgnoreDiFileChangesInGitMergeTest.java
+* https://github.com/eclipse-emf-compare/emf-compare/tree/plugins/org.eclipse.emf.compare.diagram.papyrus.tests/src/org/eclipse/emf/compare/diagram/papyrus/tests/difile/IgnoreDiFilePostProcessorTest.java
+* https://github.com/eclipse-emf-compare/emf-compare/tree/plugins/org.eclipse.emf.compare.diagram.papyrus.tests.git/src/org/eclipse/emf/compare/diagram/papyrus/tests/egit/IgnoreDiFileChangesInGitMergeTest.java
 
 === Content ===
 

--- a/plugins/org.eclipse.emf.compare.specifications/src/template.mediawiki
+++ b/plugins/org.eclipse.emf.compare.specifications/src/template.mediawiki
@@ -29,8 +29,8 @@ This user story is linked with these bugs & reviews:
 === Related Tests ===
 
 This user storys is linked with these tests:
-* http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare.q7.tests/tests/abc/XXXX.test
-* http://git.eclipse.org/c/emfcompare/org.eclipse.emf.compare.git/tree/plugins/org.eclipse.emf.compare.tests/src/org/eclipse/emf/compare/tests/abc/yyyyyy.java
+* https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare.q7.tests/tests/abc/XXXX.test
+* https://github.com/eclipse-emf-compare/emf-compare/blob/master/plugins/org.eclipse.emf.compare.tests/src/org/eclipse/emf/compare/tests/abc/yyyyyy.java
 
 === Content ===
 


### PR DESCRIPTION
The git.eclipse.org urls need to be changed to github, and gerrit is now replaced by Pull Requests