### PR TITLE
Open Guava ranges to accept v32.1.3 from Eclipse 2023-12

### DIFF
--- a/performance/org.eclipse.emf.compare.tests.performance/META-INF/MANIFEST.MF
+++ b/performance/org.eclipse.emf.compare.tests.performance/META-INF/MANIFEST.MF
@@ -25,6 +25,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jgit,
  org.eclipse.team.core,
  org.eclipse.emf.compare.rcp;bundle-version="2.4.0"
-Import-Package: com.google.common.base;version="[15.0.0,22.0.0)",
- com.google.common.collect;version="[15.0.0,22.0.0)",
- com.google.common.io;version="[15.0.0,22.0.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.diagram.ecoretools.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram.ecoretools.tests/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.5.0",
  org.eclipse.gmf.runtime.emf.core;bundle-version="1.2.2",
  org.eclipse.gmf.runtime.notation;bundle-version="1.2.0",
  org.eclipse.ui;bundle-version="3.5.0"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.emf.compare.diagram.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram.edit/META-INF/MANIFEST.MF
@@ -18,8 +18,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.gmf.runtime.notation;bundle-version="1.2.0",
  org.eclipse.gmf.runtime.notation.edit;bundle-version="1.4.0"
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.diagram.internal,
  org.eclipse.emf.compare.diagram.internal.extensions.provider;x-internal:=true,
  org.eclipse.emf.compare.diagram.internal.extensions.provider.spec,

--- a/plugins/org.eclipse.emf.compare.diagram.ide.ecoretools.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram.ide.ecoretools.tests/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.6.0",
  org.eclipse.emf.compare.ide;bundle-version="3.0.0",
  org.eclipse.emf.compare.diagram.ide.ui;bundle-version="3.0.0",
  org.eclipse.emf.compare.rcp;bundle-version="2.1.0"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.emf.compare.diagram.ide.ui.sirius/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram.ide.ui.sirius/META-INF/MANIFEST.MF
@@ -23,10 +23,10 @@ Require-Bundle: org.eclipse.compare,
  org.eclipse.gmf.runtime.diagram.ui.render;bundle-version="1.7.1",
  org.eclipse.gmf.runtime.draw2d.ui.render.awt,
  org.eclipse.sirius.common.ui
-Import-Package: com.google.common.annotations;version="[27.0.0,30.2.0)",
- com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.annotations;version="[27.0.0,33.0)",
+ com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.diagram.ide.ui.sirius.internal;x-friends:="org.eclipse.emf.compare.diagram.sirius.tests"
 Bundle-Activator: org.eclipse.emf.compare.diagram.ide.ui.sirius.CompareDiagramIDEUISiriusPlugin
 

--- a/plugins/org.eclipse.emf.compare.diagram.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram.ide.ui/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Export-Package: org.eclipse.emf.compare.diagram.ide.ui.internal;x-internal:=true
  org.eclipse.emf.compare.diagram.ide.ui.internal.preferences;x-internal:=true,
  org.eclipse.emf.compare.diagram.ide.ui.internal.structuremergeviewer.filters
 Bundle-Vendor: %providerName
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.diagram.sirius/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram.sirius/META-INF/MANIFEST.MF
@@ -7,10 +7,10 @@ Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
-Import-Package: com.google.common.annotations;version="[27.0.0,30.2.0)",
- com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.annotations;version="[27.0.0,33.0)",
+ com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.compare;bundle-version="3.2.0",
  org.eclipse.emf.compare.diagram;bundle-version="2.3.0",

--- a/plugins/org.eclipse.emf.compare.diagram/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.diagram/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.gmf.runtime.diagram.ui,
  org.eclipse.emf.compare;bundle-version="2.0.0",
  org.eclipse.emf.compare.ide;bundle-version="3.0.0"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.emf.compare.diagram.internal.CompareDiagramPlugin
 Export-Package: org.eclipse.emf.compare.diagram.internal;

--- a/plugins/org.eclipse.emf.compare.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.edit/META-INF/MANIFEST.MF
@@ -27,6 +27,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.transaction;bundle-version="1.3.0",
  org.eclipse.emf.ecore.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.annotations;version="[27.0.0,30.2.0)",
- com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.annotations;version="[27.0.0,33.0)",
+ com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.egit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.egit/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.emf.compare,
  org.eclipse.egit.ui;bundle-version="5.0.0",
  org.eclipse.compare
-Import-Package: com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/plugins/org.eclipse.emf.compare.ide.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.ide.tests/META-INF/MANIFEST.MF
@@ -17,4 +17,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Import-Package: com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.io;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.ide.ui.tests.framework/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.ide.ui.tests.framework/META-INF/MANIFEST.MF
@@ -20,5 +20,5 @@ Bundle-Vendor: %providerName
 Export-Package: org.eclipse.emf.compare.ide.ui.tests.framework,
  org.eclipse.emf.compare.ide.ui.tests.framework.annotations,
  org.eclipse.emf.compare.ide.ui.tests.framework.internal
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.ide.ui.tests.git.framework/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.ide.ui.tests.git.framework/META-INF/MANIFEST.MF
@@ -29,4 +29,4 @@ Export-Package: org.eclipse.emf.compare.ide.ui.tests.git.framework,
  org.eclipse.emf.compare.ide.ui.tests.git.framework.annotations,
  org.eclipse.emf.compare.ide.ui.tests.git.framework.internal,
  org.eclipse.emf.compare.ide.ui.tests.git.framework.internal.statements
-Import-Package: com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.collect;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.ide.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.ide.ui.tests/META-INF/MANIFEST.MF
@@ -27,10 +27,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.filesystem,
  org.eclipse.emf.compare.ide.ui.tests.framework;bundle-version="[1.0.0,2.0.0)"
 Bundle-Activator: org.eclipse.emf.compare.ide.ui.tests.Activator
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)",
- com.google.common.util.concurrent;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)",
+ com.google.common.util.concurrent;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.ide.ui.tests,
  org.eclipse.emf.compare.ide.ui.tests.contentmergeviewer.util,
  org.eclipse.emf.compare.ide.ui.tests.structuremergeviewer.actions,

--- a/plugins/org.eclipse.emf.compare.ide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.ide.ui/META-INF/MANIFEST.MF
@@ -59,10 +59,10 @@ Export-Package: org.eclipse.emf.compare.ide.ui.dependency,
  org.eclipse.emf.compare.ide.ui.mergeresolution,
  org.eclipse.emf.compare.ide.ui.source,
  org.eclipse.emf.compare.ide.ui.subscriber
-Import-Package: com.google.common.annotations;version="[27.0.0,30.2.0)",
- com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)",
- com.google.common.util.concurrent;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.annotations;version="[27.0.0,33.0)",
+ com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)",
+ com.google.common.util.concurrent;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.ide/META-INF/MANIFEST.MF
@@ -14,12 +14,12 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
-Import-Package: com.google.common.annotations;version="[27.0.0,30.2.0)", 
- com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)",
- com.google.common.util.concurrent;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.annotations;version="[27.0.0,33.0)", 
+ com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)",
+ com.google.common.util.concurrent;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.ide,
  org.eclipse.emf.compare.ide.hook,
  org.eclipse.emf.compare.ide.internal.hook;x-friends:="org.eclipse.emf.compare.ide.ui",

--- a/plugins/org.eclipse.emf.compare.rcp.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.rcp.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.compare;bundle-version="3.3.0",
  org.eclipse.emf.compare.rcp;bundle-version="2.4.0",
  org.eclipse.emf.compare.tests;bundle-version="3.3.0"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %providerName

--- a/plugins/org.eclipse.emf.compare.rcp.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.rcp.ui.tests/META-INF/MANIFEST.MF
@@ -18,9 +18,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %providerName
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.rcp.ui.tests,
  org.eclipse.emf.compare.rcp.ui.tests.mergeviewer.item,
  org.eclipse.emf.compare.rcp.ui.tests.structuremergeviewer.groups.provider,

--- a/plugins/org.eclipse.emf.compare.rcp.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.rcp.ui/META-INF/MANIFEST.MF
@@ -56,8 +56,8 @@ Export-Package: org.eclipse.emf.compare.rcp.ui,
  org.eclipse.emf.compare.rcp.ui.structuremergeviewer.filters,
  org.eclipse.emf.compare.rcp.ui.structuremergeviewer.groups,
  org.eclipse.emf.compare.rcp.ui.structuremergeviewer.groups.extender
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)",
- com.google.common.io;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)",
+ com.google.common.io;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.rcp/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.rcp/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Export-Package: org.eclipse.emf.compare.rcp,
  org.eclipse.emf.compare.rcp.internal.preferences;x-friends:="org.eclipse.emf.compare.rcp.ui,org.eclipse.emf.compare.ide.ui",
  org.eclipse.emf.compare.rcp.internal.tracer;x-friends:="org.eclipse.emf.compare.rcp.ui,org.eclipse.emf.compare.ide.ui",
  org.eclipse.emf.compare.rcp.policy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.tests/META-INF/MANIFEST.MF
@@ -56,7 +56,7 @@ Export-Package: org.eclipse.emf.compare.tests,
  org.eclipse.emf.compare.tests.suite,
  org.eclipse.emf.compare.tests.unit,
  org.eclipse.emf.compare.tests.utils
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.emf.compare.uml2.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.edit/META-INF/MANIFEST.MF
@@ -19,8 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.uml2.types;visibility:=reexport,
  org.eclipse.emf.compare.edit;bundle-version="4.2.0";visibility:=reexport
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
  org.eclipse.emf.compare.provider
 Export-Package: org.eclipse.emf.compare.uml2.internal,
  org.eclipse.emf.compare.uml2.internal.provider;x-internal:=true,

--- a/plugins/org.eclipse.emf.compare.uml2.ide.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.ide.tests/META-INF/MANIFEST.MF
@@ -17,6 +17,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.compare.uml2.rcp
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.uml2.ide.tests.util

--- a/plugins/org.eclipse.emf.compare.uml2.ide.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.ide.ui.tests/META-INF/MANIFEST.MF
@@ -24,6 +24,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.compare.ide.ui.tests;bundle-version="4.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.uml2.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.ide/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"

--- a/plugins/org.eclipse.emf.compare.uml2.rcp.ui.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.rcp.ui.tests/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.uml2.rcp.ui.tests.groups

--- a/plugins/org.eclipse.emf.compare.uml2.rcp.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.rcp.ui/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.emf.edit.ui;bundle-version="2.5.0",
  org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.uml2.uml;bundle-version="5.0.0",
  org.eclipse.emf.compare.edit;bundle-version="3.0.0"
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.eclipse.emf.compare.uml2.rcp.ui.internal.accessor;x-internal:=true,

--- a/plugins/org.eclipse.emf.compare.uml2.rcp/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.rcp/META-INF/MANIFEST.MF
@@ -11,6 +11,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.uml2.rcp.internal.policy;x-friends:="org.eclipse.emf.compare.uml2.ide"

--- a/plugins/org.eclipse.emf.compare.uml2.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2.tests/META-INF/MANIFEST.MF
@@ -32,7 +32,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.compare.ide;bundle-version="3.3.0",
  org.hamcrest.library;bundle-version="1.3.0"
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
  org.eclipse.emf.compare.rcp
 Bundle-Activator: org.eclipse.emf.compare.uml2.profile.test.uml2comparetestprofile.provider.UML2CompareTestProfileEditPlugin$Implementation

--- a/plugins/org.eclipse.emf.compare.uml2/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare.uml2/META-INF/MANIFEST.MF
@@ -14,9 +14,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.compare;bundle-version="3.4.0";visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.emf.compare.uml2.internal.UMLComparePlugin
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.primitives;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.primitives;version="[27.0.0,33.0)"
 Export-Package: org.eclipse.emf.compare.uml2.internal;
   x-friends:="org.eclipse.emf.compare.uml2.edit,
    org.eclipse.emf.compare.uml2.rcp,

--- a/plugins/org.eclipse.emf.compare/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.compare/META-INF/MANIFEST.MF
@@ -40,7 +40,7 @@ Export-Package: org.eclipse.emf.compare,
 Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.ecore.xmi;bundle-version="2.5.0"
 Bundle-ActivationPolicy: lazy
-Import-Package: com.google.common.base;version="[27.0.0,30.2.0)",
- com.google.common.cache;version="[27.0.0,30.2.0)",
- com.google.common.collect;version="[27.0.0,30.2.0)",
- com.google.common.eventbus;version="[27.0.0,30.2.0)"
+Import-Package: com.google.common.base;version="[27.0.0,33.0)",
+ com.google.common.cache;version="[27.0.0,33.0)",
+ com.google.common.collect;version="[27.0.0,33.0)",
+ com.google.common.eventbus;version="[27.0.0,33.0)"


### PR DESCRIPTION
See https://github.com/eclipse-emf-compare/emf-compare/issues/14