### PR TITLE
#39 NullPointerException when comparing ordered features

### DIFF
--- a/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/equi/DefaultEquiEngine.java
+++ b/plugins/org.eclipse.emf.compare/src/org/eclipse/emf/compare/equi/DefaultEquiEngine.java
@@ -100,9 +100,6 @@ public class DefaultEquiEngine implements IEquiEngine {
 			// If no equivalence, create one
 			equivalence = CompareFactory.eINSTANCE.createEquivalence();
 
-			// Add the current difference to the equivalence
-			equivalence.getDifferences().add(referenceChange);
-
 			/*
 			 * Add the difference where the value is the object containing the current difference, which is
 			 * contained by the value of the current difference, where the reference is linked to the opposite
@@ -144,8 +141,11 @@ public class DefaultEquiEngine implements IEquiEngine {
 
 				addChangesFromOrigin(comparison, referenceChange, equivalence);
 			}
-			if (equivalence.getDifferences().size() > 1) {
+			if (!equivalence.getDifferences().isEmpty()) {
 				comparison.getEquivalences().add(equivalence);
+
+				// Add the current difference to the equivalence
+				equivalence.getDifferences().add(referenceChange);
 			}
 		}
 	}


### PR DESCRIPTION
fix [NPE](https://github.com/eclipse-emf-compare/emf-compare/issues/39): setting equivalence for difference when the equivalence has only one difference doesn't make sense